### PR TITLE
Disable NewsArticle schema SEO issue on landing pages

### DIFF
--- a/ispider_core/seo/checks/technical.py
+++ b/ispider_core/seo/checks/technical.py
@@ -90,6 +90,8 @@ class SchemaNewsArticleCheck:
     required_fields = ["headline", "datePublished", "dateModified", "author", "image", "publisher"]
 
     def run(self, resp: dict):
+        if resp.get("request_discriminator") == "landing_page":
+            return []
         if resp.get("status_code") != 200:
             return []
         content = resp.get("content")


### PR DESCRIPTION
### Motivation
- Prevent landing pages from emitting `SCHEMA_NEWSARTICLE_MISSING` SEO issues during crawling because landing pages are not expected to include `NewsArticle` schema.

### Description
- Add an early return in `SchemaNewsArticleCheck.run()` in `ispider_core/seo/checks/technical.py` to skip the schema check when `resp.get("request_discriminator") == "landing_page"`.

### Testing
- Ran `python -m py_compile ispider_core/seo/checks/technical.py` and verified the code diff; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2cd41aa4832d978f0140e058ef91)